### PR TITLE
Acessibilidade: suporte a leitor de tela no Jogo da Memória

### DIFF
--- a/src/app/pages/games/puzzles/puzzles.component.css
+++ b/src/app/pages/games/puzzles/puzzles.component.css
@@ -24,6 +24,19 @@
   padding: 10px;
 }
 
+/* Esconde visualmente mas mantém disponível para leitores de tela (região aria-live) */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 .card {
   width: 100%;
   aspect-ratio: 3 / 3;
@@ -32,6 +45,11 @@
   perspective: 1000px;
   cursor: pointer;
   border-radius: 18px;
+}
+
+.card:focus-visible {
+  outline: 3px solid #2563eb;
+  outline-offset: 3px;
 }
 
 .card-inner {

--- a/src/app/pages/games/puzzles/puzzles.component.html
+++ b/src/app/pages/games/puzzles/puzzles.component.html
@@ -6,19 +6,27 @@
     <div class="timer">Tempo: {{ timeElapsed }}</div>
   </div>
 
+  <!-- Região de anúncios para leitores de tela: informa o que acontece a cada jogada -->
+  <div class="sr-only" aria-live="polite" aria-atomic="true">{{ announcement }}</div>
+
   <div class="memory-board">
-    <div class="cards-grid">
+    <div class="cards-grid" role="group" [attr.aria-label]="'Tabuleiro do jogo da memória, ' + cards.length + ' cartas'">
       <div *ngFor="let card of cards"
            class="card"
+           role="button"
+           tabindex="0"
            [class.flipped]="card.isFlipped"
            [class.matched]="card.isMatched"
-           (click)="flipCard(card)">
+           [attr.aria-label]="getCardLabel(card)"
+           [attr.aria-pressed]="card.isFlipped || card.isMatched"
+           (click)="flipCard(card)"
+           (keydown)="onCardKeydown($event, card)">
         <div class="card-inner">
           <div class="card-front">
-            <img src="public/images/card-back.png" alt="Verso da carta">
+            <img src="public/images/card-back.png" alt="" aria-hidden="true">
           </div>
           <div class="card-back">
-            <img [src]="card.image" [alt]="'Imagem ' + card.id">
+            <img [src]="card.image" [alt]="card.name">
           </div>
         </div>
       </div>

--- a/src/app/pages/games/puzzles/puzzles.component.ts
+++ b/src/app/pages/games/puzzles/puzzles.component.ts
@@ -4,6 +4,7 @@ import { CommonModule } from '@angular/common';
 interface Card {
   id: number;
   image: string;
+  name: string;
   isFlipped: boolean;
   isMatched: boolean;
 }
@@ -23,6 +24,7 @@ export class PuzzlesComponent implements OnInit {
   private flippedCards: Card[] = [];
   private canFlip: boolean = true;
   gameWon: boolean = false;
+  announcement: string = '';
 
   ngOnInit() {
     this.startNewGame();
@@ -39,28 +41,29 @@ export class PuzzlesComponent implements OnInit {
     this.startTimer();
 
     // Inicializar as cartas
-    const images = [
-      'public/images/charles_babbage.png',
-      'public/images/ada_lovelace.png',
-      'public/images/eniac.png',
-      'public/images/alan_turing.png',
-      'public/images/transitor.png',
-      'public/images/internet.png',
-      'public/images/steve_jobs.png',
-      'public/images/bill_gates.png',
-      'public/images/quantum.png'
+    const images: { image: string; name: string }[] = [
+      { image: 'public/images/charles_babbage.png', name: 'Charles Babbage' },
+      { image: 'public/images/ada_lovelace.png', name: 'Ada Lovelace' },
+      { image: 'public/images/eniac.png', name: 'ENIAC' },
+      { image: 'public/images/alan_turing.png', name: 'Alan Turing' },
+      { image: 'public/images/transitor.png', name: 'Transistor' },
+      { image: 'public/images/internet.png', name: 'Internet' },
+      { image: 'public/images/steve_jobs.png', name: 'Steve Jobs' },
+      { image: 'public/images/bill_gates.png', name: 'Bill Gates' },
+      { image: 'public/images/quantum.png', name: 'Computação Quântica' }
     ];
 
     // Criar pares de cartas
     this.cards = [];
     let id = 1;
-    images.forEach(image => {
-      this.cards.push({ id: id++, image, isFlipped: false, isMatched: false });
-      this.cards.push({ id: id++, image, isFlipped: false, isMatched: false });
+    images.forEach(({ image, name }) => {
+      this.cards.push({ id: id++, image, name, isFlipped: false, isMatched: false });
+      this.cards.push({ id: id++, image, name, isFlipped: false, isMatched: false });
     });
 
     // Embaralhar as cartas
     this.shuffleCards();
+    this.announcement = 'Novo jogo iniciado. ' + this.cards.length + ' cartas embaralhadas.';
   }
 
   private shuffleCards() {
@@ -87,6 +90,7 @@ export class PuzzlesComponent implements OnInit {
 
     card.isFlipped = true;
     this.flippedCards.push(card);
+    this.announcement = `Carta virada: ${card.name}.`;
 
     if (this.flippedCards.length === 2) {
       this.canFlip = false;
@@ -102,21 +106,43 @@ export class PuzzlesComponent implements OnInit {
       card2.isMatched = true;
       this.flippedCards = [];
       this.canFlip = true;
+      this.announcement = `Par encontrado: ${card1.name}.`;
 
       // Verificar se o jogo acabou
       if (this.cards.every(card => card.isMatched)) {
         clearInterval(this.timerInterval);
         setTimeout(() => {
           this.gameWon = true;
+          this.announcement = `Parabéns! Você completou o jogo da memória em ${this.timeElapsed}.`;
         }, 500);
       }
     } else {
+      this.announcement = `${card1.name} e ${card2.name} não formam um par. Cartas serão fechadas novamente.`;
       setTimeout(() => {
         card1.isFlipped = false;
         card2.isFlipped = false;
         this.flippedCards = [];
         this.canFlip = true;
       }, 1000);
+    }
+  }
+
+  /** Rótulo acessível de cada carta, usado no aria-label para leitores de tela. */
+  getCardLabel(card: Card): string {
+    if (card.isMatched) {
+      return `Carta ${card.name}, par já encontrado.`;
+    }
+    if (card.isFlipped) {
+      return `Carta ${card.name}, virada.`;
+    }
+    return `Carta fechada, posição ${this.cards.indexOf(card) + 1} de ${this.cards.length}. Pressione Enter para virar.`;
+  }
+
+  /** Permite virar a carta pelo teclado (Enter ou Espaço), equivalente ao clique do mouse. */
+  onCardKeydown(event: KeyboardEvent, card: Card) {
+    if (event.key === 'Enter' || event.key === ' ' || event.key === 'Spacebar') {
+      event.preventDefault();
+      this.flipCard(card);
     }
   }
 }


### PR DESCRIPTION
Corrige os problemas de acessibilidade do Jogo da Memória, relatados por uma aluna usuária de leitor de tela (NVDA), referentes à Atividade 5 (Acessibilidade).

Antes, as cartas não podiam ser identificadas nem operadas via leitor de tela: não havia indicação de qual imagem foi revelada, nem suporte a navegação/interação por teclado.

O que foi feito:

- Nomes descritivos por carta: cada imagem passou a ter um nome legível (ex: "Ada Lovelace", "ENIAC") em vez de expor apenas o caminho do arquivo.
- As cartas ficaram focáveis por teclado e podem ser viradas com Enter ou Espaço, não só com clique do mouse.
- O leitor de tela agora anuncia o estado de cada carta ao passar o foco nela: se está fechada, virada ou já pareada.
- O jogo passou a avisar automaticamente, em voz alta, quando uma carta é virada, quando um par é encontrado ou errado, e quando o jogo é vencido, sem precisar navegar manualmente até essa informação.
- Foi adicionado um indicador visual de foco para quem navega só com teclado.
- A imagem decorativa do verso da carta foi marcada para ser ignorada pelo leitor de tela, evitando repetição desnecessária.

Arquivos alterados:

- src/app/pages/games/puzzles/puzzles.component.ts
- src/app/pages/games/puzzles/puzzles.component.html
- src/app/pages/games/puzzles/puzzles.component.css

Como testar:

Rodar ng serve e abrir o Jogo da Memória. Navegar pelas cartas usando Tab e ativar com Enter ou Espaço. Testar com o NVDA ativo: o leitor deve anunciar o estado de cada carta ao focar, e anunciar automaticamente cartas viradas, pares e vitória.

Observações:

- A lógica do jogo (embaralhar, verificar pares, cronômetro) não foi alterada — apenas foram adicionadas as camadas de acessibilidade sobre o comportamento existente.
- Build validado com ng build, sem erros.
- Segue o padrão eMAG (Modelo de Acessibilidade em Governo Eletrônico) exigido na atividade.