### PR TITLE
Acessibilidade: navegação por teclado e leitor de tela no Caça-Palavras

### DIFF
--- a/src/app/pages/games/word-search/word-search.component.html
+++ b/src/app/pages/games/word-search/word-search.component.html
@@ -4,16 +4,33 @@
     <div class="words-found">Palavras encontradas: {{ foundWordsCount }}/{{ words.length }}</div>
   </div>
 
+  <p class="sr-only">
+    Use as setas do teclado para navegar entre as letras. Pressione Enter ou Espaço numa
+    letra para iniciar a seleção de uma palavra, mova até a última letra dela e pressione
+    Enter ou Espaço novamente para confirmar. Pressione Escape para cancelar a seleção atual.
+  </p>
+
+  <!-- Região de anúncios para leitores de tela: seleção iniciada, palavra encontrada, etc. -->
+  <div class="sr-only" aria-live="polite" aria-atomic="true">{{ announcement }}</div>
+
   <div class="grid-container">
-    <div class="grid" 
+    <div class="grid"
+         role="grid"
+         [attr.aria-label]="'Grade de caça-palavras, ' + grid.length + ' linhas por ' + (grid[0]?.length || 0) + ' colunas'"
          (mouseleave)="onMouseUp()"
          (mouseup)="onMouseUp()">
-      <div class="row" *ngFor="let row of grid; let i = index">
-        <div class="cell" 
+      <div class="row" role="row" *ngFor="let row of grid; let i = index">
+        <div class="cell"
+             role="gridcell"
              *ngFor="let cell of row; let j = index"
+             [id]="'cell-' + i + '-' + j"
+             [tabindex]="(focusedRow === i && focusedCol === j) ? 0 : -1"
              [class.selected]="isCellSelected(i, j)"
+             [attr.aria-label]="getCellLabel(cell, i, j)"
+             [attr.aria-selected]="isCellSelected(i, j)"
              (mousedown)="onMouseDown(i, j)"
-             (mouseover)="onMouseOver(i, j)">
+             (mouseover)="onMouseOver(i, j)"
+             (keydown)="onCellKeydown($event, i, j)">
           {{ cell }}
         </div>
       </div>
@@ -21,10 +38,10 @@
   </div>
 
   <div class="word-list">
-    <h3>Palavras para encontrar:</h3>
-    <ul>
+    <h3 id="word-list-heading">Palavras para encontrar:</h3>
+    <ul aria-labelledby="word-list-heading">
       <li *ngFor="let word of words" [class.found]="word.found">
-        {{ word.word }}
+        {{ word.word }}<span class="sr-only" *ngIf="word.found"> — encontrada</span>
       </li>
     </ul>
   </div>
@@ -34,11 +51,5 @@
 
 <!-- Modal de Parabéns -->
 <div class="modal-overlay" *ngIf="showCongratulations">
-  <div class="modal-content">
-    <h2 class="modal-title">🎉 Parabéns! 🎉</h2>
-    <p class="modal-message">
-      Você encontrou todas as palavras em {{ formatTime(elapsedTime) }}!
-    </p>
-    <button class="modal-button" (click)="closeModal()">Fechar</button>
-  </div>
-</div> 
+  <div class="modal-content" role="dialog" aria-modal="true" aria-labelledby="modal-title">
+    <h2 class="modal-title" id="modal-title" tabindex="-1">🎉 Parabéns! 🎉</h2>

--- a/src/app/pages/games/word-search/word-search.component.scss
+++ b/src/app/pages/games/word-search/word-search.component.scss
@@ -52,6 +52,26 @@
     background-color: #4CAF50;
     color: white;
   }
+
+  &:focus-visible {
+    outline: 3px solid #2563eb;
+    outline-offset: -3px;
+    z-index: 1;
+    position: relative;
+  }
+}
+
+/* Esconde visualmente mas mantém disponível para leitores de tela (instruções e anúncios) */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 .word-list {
@@ -152,4 +172,4 @@
   &:hover {
     background-color: #45a049;
   }
-} 
+}

--- a/src/app/pages/games/word-search/word-search.component.ts
+++ b/src/app/pages/games/word-search/word-search.component.ts
@@ -19,6 +19,9 @@ export class WordSearchComponent implements OnInit, OnDestroy {
   isSelecting: boolean = false;
   gameComplete: boolean = false;
   showCongratulations: boolean = false;
+  focusedRow: number = 0;
+  focusedCol: number = 0;
+  announcement: string = '';
   private subscriptions: Subscription[] = [];
 
   constructor(private gameService: GameService) {}
@@ -40,6 +43,11 @@ export class WordSearchComponent implements OnInit, OnDestroy {
           this.gameComplete = true;
           this.gameService.endGame();
           this.showCongratulations = true;
+          // Move o foco para o título do modal assim que ele for renderizado,
+          // garantindo que o NVDA anuncie a vitória automaticamente
+          setTimeout(() => {
+            document.getElementById('modal-title')?.focus();
+          });
         }
       })
     );
@@ -77,9 +85,12 @@ export class WordSearchComponent implements OnInit, OnDestroy {
   onMouseUp(): void {
     if (this.isSelecting) {
       this.isSelecting = false;
+      const selectedText = this.selectedCells.map(p => this.grid[p.row][p.col]).join('');
       if (this.gameService.checkWord(this.selectedCells)) {
         // Palavra encontrada!
+        this.announcement = `Palavra encontrada: ${selectedText}!`;
       } else {
+        this.announcement = `Nenhuma palavra corresponde a "${selectedText}". Seleção desfeita.`;
         this.selectedCells = [];
       }
     }
@@ -113,6 +124,69 @@ export class WordSearchComponent implements OnInit, OnDestroy {
     return this.words.find(w => w.word === word)?.found || false;
   }
 
+  /** Verifica se a célula faz parte de uma palavra já encontrada, para informar o leitor de tela. */
+  isCellInFoundWord(row: number, col: number): boolean {
+    return this.words.some(w => w.found && w.positions.some(p => p.row === row && p.col === col));
+  }
+
+  /** Monta o texto que o NVDA anuncia ao focar em cada célula da grade. */
+  getCellLabel(cell: string, row: number, col: number): string {
+    let label = `Letra ${cell}, linha ${row + 1}, coluna ${col + 1}`;
+    if (this.isCellSelected(row, col)) {
+      label += ', selecionada';
+    }
+    if (this.isCellInFoundWord(row, col)) {
+      label += ', parte de uma palavra já encontrada';
+    }
+    return label;
+  }
+
+  /**
+   * Navegação e seleção por teclado, equivalente ao arrastar do mouse:
+   * setas movem o foco pela grade; Enter/Espaço inicia a seleção numa letra
+   * e a confirma na letra final; Escape cancela a seleção em andamento.
+   */
+  onCellKeydown(event: KeyboardEvent, row: number, col: number): void {
+    const arrowKeys = ['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'];
+
+    if (arrowKeys.includes(event.key)) {
+      event.preventDefault();
+      let newRow = row;
+      let newCol = col;
+
+      if (event.key === 'ArrowUp') newRow = Math.max(0, row - 1);
+      if (event.key === 'ArrowDown') newRow = Math.min(this.grid.length - 1, row + 1);
+      if (event.key === 'ArrowLeft') newCol = Math.max(0, col - 1);
+      if (event.key === 'ArrowRight') newCol = Math.min(this.grid[0].length - 1, col + 1);
+
+      this.focusedRow = newRow;
+      this.focusedCol = newCol;
+
+      // Se já existe uma seleção em andamento, estende-a até a nova posição
+      if (this.isSelecting) {
+        this.onMouseOver(newRow, newCol);
+      }
+
+      // Move o foco real do navegador para a nova célula, após o Angular
+      // atualizar o tabindex (roving tabindex)
+      setTimeout(() => {
+        document.getElementById(`cell-${newRow}-${newCol}`)?.focus();
+      });
+    } else if (event.key === 'Enter' || event.key === ' ' || event.key === 'Spacebar') {
+      event.preventDefault();
+      if (!this.isSelecting) {
+        this.onMouseDown(row, col);
+        this.announcement = `Seleção iniciada na letra ${this.grid[row][col]}, linha ${row + 1}, coluna ${col + 1}. Use as setas até a última letra e pressione Enter para confirmar.`;
+      } else {
+        this.onMouseUp();
+      }
+    } else if (event.key === 'Escape' && this.isSelecting) {
+      this.isSelecting = false;
+      this.selectedCells = [];
+      this.announcement = 'Seleção cancelada.';
+    }
+  }
+
   closeModal(): void {
     this.showCongratulations = false;
   }
@@ -124,5 +198,8 @@ export class WordSearchComponent implements OnInit, OnDestroy {
     this.selectedCells = [];
     this.gameComplete = false;
     this.showCongratulations = false;
+    this.focusedRow = 0;
+    this.focusedCol = 0;
+    this.announcement = 'Jogo reiniciado.';
   }
 }


### PR DESCRIPTION
Corrige os problemas de acessibilidade do Caça-Palavras, relatados na Atividade 5. O relato original era de erros relacionados à orientação das letras durante a navegação.

A causa raiz era que o jogo só podia ser jogado arrastando o mouse sobre as letras. Não existia absolutamente nenhuma forma de selecionar uma palavra usando apenas o teclado, e a grade de letras não tinha nenhuma estrutura semântica que um leitor de tela pudesse interpretar.

O que foi feito:
A grade de letras ganhou a estrutura de uma grade de verdade, permitindo que o leitor de tela entenda que aquilo é organizado em linhas e colunas.
Agora dá para navegar entre as letras usando as setas do teclado, célula por célula, em qualquer direção.
Foi criado um sistema de seleção por teclado equivalente ao arrastar do mouse: Enter ou Espaço na primeira letra inicia a seleção, as setas estendem a seleção até a última letra da palavra, e Enter ou Espaço novamente confirma. Escape cancela uma seleção em andamento.
Cada letra agora tem uma descrição falada pelo leitor de tela, informando a letra, a linha, a coluna, se está selecionada, e se já faz parte de uma palavra encontrada anteriormente.
O jogo agora avisa automaticamente, em voz alta, quando uma seleção é iniciada, quando uma palavra é encontrada ou não corresponde a nada, e quando o jogo é reiniciado.
Foi adicionado um texto de instrução, apenas para leitores de tela, explicando o esquema de navegação por teclado logo no início da página.
Palavras já encontradas na lista agora também têm um texto indicando isso, além do risco visual que já existia.
O modal de vitória foi marcado como uma caixa de diálogo, e o foco é movido automaticamente para o título dele assim que aparece, garantindo que o leitor de tela anuncie a conclusão do jogo sem precisar navegar manualmente até lá.

Arquivos alterados:
src/app/pages/games/word-search/word-search.component.ts
src/app/pages/games/word-search/word-search.component.html
src/app/pages/games/word-search/word-search.component.scss

Como testar:
Rodar ng serve e abrir o Caça-Palavras. Navegar pela grade usando as setas do teclado, sem usar o mouse. Selecionar uma palavra completa usando Enter para iniciar e confirmar a seleção. Testar com o NVDA ativo: o leitor deve anunciar cada letra com sua posição, o início e o resultado de cada seleção, e o título da tela de vitória automaticamente ao concluir o jogo.