### PR TITLE
Componentes Reutilizáveis: botões de compartilhamento

### DIFF
--- a/src/app/pages/news/news-detail.component.html
+++ b/src/app/pages/news/news-detail.component.html
@@ -17,6 +17,9 @@
 
     <mat-card-content class="news-detail-content">
       <p class="news-detail-description">{{ newsItem.summary.description }}</p>
+
+      <app-share-buttons [title]="newsItem.summary.title"></app-share-buttons>
+
       <hr class="news-separator">
       <div class="news-full-content" *ngIf="newsItem.fullContent && newsItem.fullContent.length">
         <div *ngFor="let item of newsItem.fullContent" [ngSwitch]="item.type" class="content-item">

--- a/src/app/pages/news/news-detail.component.ts
+++ b/src/app/pages/news/news-detail.component.ts
@@ -6,6 +6,7 @@ import { map, Observable, switchMap } from 'rxjs';
 import {MatIconModule} from '@angular/material/icon';
 import {MatCardModule} from '@angular/material/card';
 import {MatIconButton} from '@angular/material/button';
+import { ShareButtonsComponent } from '@shared/components/share-buttons/share-buttons.component';
 
 
 @Component({
@@ -16,7 +17,8 @@ import {MatIconButton} from '@angular/material/button';
     RouterModule,
     MatCardModule,
     MatIconModule,
-    MatIconButton
+    MatIconButton,
+    ShareButtonsComponent
   ],
   templateUrl: './news-detail.component.html',
   styleUrl: './news-detail.component.scss'

--- a/src/app/pages/personalities/personalities-detail.component.html
+++ b/src/app/pages/personalities/personalities-detail.component.html
@@ -17,6 +17,9 @@
 
     <mat-card-content class="personality-detail-content">
       <p class="personality-detail-description">{{ personalityItem.summary.description }}</p>
+
+      <app-share-buttons [title]="personalityItem.summary.title"></app-share-buttons>
+
       <hr class="personality-separator">
       <div class="personality-full-content" *ngIf="personalityItem.fullContent && personalityItem.fullContent.length">
         <div *ngFor="let item of personalityItem.fullContent" [ngSwitch]="item.type" class="content-item">

--- a/src/app/pages/personalities/personalities-detail.component.ts
+++ b/src/app/pages/personalities/personalities-detail.component.ts
@@ -6,6 +6,7 @@ import { Observable } from 'rxjs';
 import {MatIconModule} from '@angular/material/icon';
 import {MatCardModule} from '@angular/material/card';
 import {MatIconButton} from '@angular/material/button';
+import { ShareButtonsComponent } from '@shared/components/share-buttons/share-buttons.component';
 
 
 @Component({
@@ -16,7 +17,8 @@ import {MatIconButton} from '@angular/material/button';
     RouterModule,
     MatCardModule,
     MatIconModule,
-    MatIconButton
+    MatIconButton,
+    ShareButtonsComponent
   ],
   templateUrl: './personalities-detail.component.html',
   styleUrl: './personalities-detail.component.scss'

--- a/src/app/pages/videos/video-detail/video-detail.component.html
+++ b/src/app/pages/videos/video-detail/video-detail.component.html
@@ -12,6 +12,8 @@
         <article class="video-description">
             <p>{{video.description}}</p>
         </article>
+
+        <app-share-buttons [title]="video.summary.title"></app-share-buttons>
     </mat-card-content>
     <div class="divider"></div>
     <mat-card-footer class="colaborators-container">

--- a/src/app/pages/videos/video-detail/video-detail.component.ts
+++ b/src/app/pages/videos/video-detail/video-detail.component.ts
@@ -6,13 +6,14 @@ import { Observable, switchMap } from "rxjs";
 import { ActivatedRoute, Router, RouterLink } from "@angular/router";
 import { CommonModule } from "@angular/common";
 import { MatIcon } from "@angular/material/icon";
+import { ShareButtonsComponent } from "@shared/components/share-buttons/share-buttons.component";
 
 @Component({
     selector: 'app-video-detail',
     standalone: true,
     templateUrl: './video-detail.component.html',
     styleUrl: './video-detail.component.scss',
-    imports: [MatCard, MatCardHeader, MatCardTitle, MatCardSubtitle, MatCardContent, VideoPlayerComponent, MatCardFooter, CommonModule, MatCardActions, MatIcon, RouterLink]
+    imports: [MatCard, MatCardHeader, MatCardTitle, MatCardSubtitle, MatCardContent, VideoPlayerComponent, MatCardFooter, CommonModule, MatCardActions, MatIcon, RouterLink, ShareButtonsComponent]
 })
 export class VideoDetailComponent implements OnInit {
     video$: Observable<Video | undefined>;

--- a/src/app/shared/components/share-buttons/share-buttons.component.html
+++ b/src/app/shared/components/share-buttons/share-buttons.component.html
@@ -1,0 +1,14 @@
+<div class="share-buttons" role="group" aria-label="Compartilhar este conteúdo">
+	<span class="share-label">Compartilhar:</span>
+
+	<button
+		type="button"
+		*ngFor="let link of shareLinks"
+		[class]="'share-button share-button--' + link.name"
+		[attr.aria-label]="link.label"
+		[title]="link.label"
+		(click)="share(link, $event)"
+	>
+		<i [class]="link.icon" aria-hidden="true"></i>
+	</button>
+</div>

--- a/src/app/shared/components/share-buttons/share-buttons.component.scss
+++ b/src/app/shared/components/share-buttons/share-buttons.component.scss
@@ -1,0 +1,61 @@
+.share-buttons {
+	display: flex;
+	align-items: center;
+	flex-wrap: wrap;
+	gap: 0.6rem;
+	padding: 0.5rem 0;
+}
+
+.share-label {
+	font-weight: 600;
+	color: #333;
+	margin-right: 0.25rem;
+}
+
+.share-button {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 36px;
+	height: 36px;
+	border-radius: 50%;
+	border: none;
+	color: #fff;
+	text-decoration: none;
+	cursor: pointer;
+	font-size: 16px;
+	font-family: inherit;
+	padding: 0;
+	transition: transform 0.15s ease, filter 0.15s ease;
+
+	&:hover {
+		filter: brightness(0.88);
+		transform: scale(1.08);
+	}
+
+	&:focus-visible {
+		outline: 3px solid #2563eb;
+		outline-offset: 2px;
+	}
+}
+
+/* Cores de marca de cada rede social */
+.share-button--facebook {
+	background-color: #1877f2;
+}
+
+.share-button--x {
+	background-color: #000000;
+}
+
+.share-button--linkedin {
+	background-color: #0a66c2;
+}
+
+.share-button--telegram {
+	background-color: #29a9eb;
+}
+
+.share-button--whatsapp {
+	background-color: #25d366;
+}

--- a/src/app/shared/components/share-buttons/share-buttons.component.ts
+++ b/src/app/shared/components/share-buttons/share-buttons.component.ts
@@ -1,0 +1,117 @@
+import { Component, Input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+/**
+ * Representa uma rede social suportada pelo componente de compartilhamento.
+ */
+interface ShareLink {
+	/** Identificador interno da rede (usado no nome da janela popup). */
+	name: string;
+	/** Classe do ícone do Font Awesome (marca). */
+	icon: string;
+	/** Rótulo acessível, exibido no aria-label e no title do botão. */
+	label: string;
+	/** Monta a URL de compartilhamento a partir da URL e do título já codificados. */
+	buildUrl: (encodedUrl: string, encodedTitle: string) => string;
+}
+
+/**
+ * Componente ShareButtonsComponent exibe um conjunto de botões reutilizáveis para
+ * compartilhar uma página em redes sociais (Facebook, X, LinkedIn, Telegram e WhatsApp).
+ *
+ * É genérico e não depende do tipo de conteúdo -- pode ser usado em qualquer página de
+ * detalhe (notícia, vídeo, personalidade, revista, etc.), bastando informar a URL e o
+ * título a compartilhar.
+ *
+ * @example
+ * <app-share-buttons [title]="newsItem.summary.title"></app-share-buttons>
+ *
+ * @example
+ * <!-- Informando a URL explicitamente, em vez de usar a URL atual da página -->
+ * <app-share-buttons [url]="fullUrl" [title]="video.summary.title"></app-share-buttons>
+ */
+@Component({
+	selector: 'app-share-buttons',
+	standalone: true,
+	imports: [CommonModule],
+	templateUrl: './share-buttons.component.html',
+	styleUrl: './share-buttons.component.scss',
+})
+export class ShareButtonsComponent {
+	/**
+	 * URL a ser compartilhada. Se não for informada, usa a URL atual do navegador
+	 * (window.location.href) no momento do clique.
+	 */
+	@Input() url?: string;
+
+	/**
+	 * Título ou texto a acompanhar o link, usado pelas redes que suportam
+	 * (X, Telegram, WhatsApp). Facebook e LinkedIn ignoram este campo.
+	 */
+	@Input() title: string = '';
+
+	/** Lista de redes sociais suportadas, na ordem em que são exibidas. */
+	readonly shareLinks: ShareLink[] = [
+		{
+			name: 'facebook',
+			icon: 'fa-brands fa-facebook-f',
+			label: 'Compartilhar no Facebook',
+			buildUrl: encodedUrl => `https://www.facebook.com/sharer/sharer.php?u=${encodedUrl}`,
+		},
+		{
+			name: 'x',
+			icon: 'fa-brands fa-x-twitter',
+			label: 'Compartilhar no X',
+			buildUrl: (encodedUrl, encodedTitle) =>
+				`https://twitter.com/intent/tweet?url=${encodedUrl}&text=${encodedTitle}`,
+		},
+		{
+			name: 'linkedin',
+			icon: 'fa-brands fa-linkedin-in',
+			label: 'Compartilhar no LinkedIn',
+			buildUrl: encodedUrl => `https://www.linkedin.com/sharing/share-offsite/?url=${encodedUrl}`,
+		},
+		{
+			name: 'telegram',
+			icon: 'fa-brands fa-telegram',
+			label: 'Compartilhar no Telegram',
+			buildUrl: (encodedUrl, encodedTitle) =>
+				`https://t.me/share/url?url=${encodedUrl}&text=${encodedTitle}`,
+		},
+		{
+			name: 'whatsapp',
+			icon: 'fa-brands fa-whatsapp',
+			label: 'Compartilhar no WhatsApp',
+			buildUrl: (encodedUrl, encodedTitle) =>
+				`https://api.whatsapp.com/send?text=${encodedTitle}%20${encodedUrl}`,
+		},
+	];
+
+	/**
+	 * Abre a janela de compartilhamento da rede escolhida.
+	 * A URL é lida no momento do clique (não no ngOnInit), para que o componente
+	 * continue funcionando corretamente mesmo em páginas onde a URL muda sem o
+	 * componente ser recriado (ex: navegação entre "próxima notícia"/"anterior").
+	 * @param link - A rede social escolhida.
+	 * @param event - O evento de clique, usado para impedir a navegação padrão do link.
+	 */
+	share(link: ShareLink, event: MouseEvent): void {
+		event.preventDefault();
+
+		const pageUrl = this.url ?? window.location.href;
+		const encodedUrl = encodeURIComponent(pageUrl);
+		const encodedTitle = encodeURIComponent(this.title ?? '');
+		const shareUrl = link.buildUrl(encodedUrl, encodedTitle);
+
+		const width = 600;
+		const height = 500;
+		const left = Math.max(0, (window.screen.width - width) / 2);
+		const top = Math.max(0, (window.screen.height - height) / 2);
+
+		window.open(
+			shareUrl,
+			`share-${link.name}`,
+			`width=${width},height=${height},left=${left},top=${top},noopener,noreferrer`
+		);
+	}
+}


### PR DESCRIPTION
Implementa os botões de compartilhamento reutilizáveis pedidos no tópico 4 da Atividade de Componentes Reutilizáveis.

Foi criado um componente novo, ShareButtonsComponent, em shared/components/share-buttons. Ele é genérico e não depende do tipo de conteúdo: recebe apenas um título e, opcionalmente, uma URL, e funciona para qualquer página de detalhe do site.

O componente foi integrado nas três páginas de detalhe que já existem: notícia, personalidade e vídeo, aparecendo logo abaixo da descrição de cada uma.

São exibidos cinco botões, um para cada rede: Facebook, X, LinkedIn, Telegram e WhatsApp, usando os ícones de marca do Font Awesome que já estavam disponíveis no projeto. Ao clicar em qualquer um, abre uma janela pop-up com a tela de compartilhamento da rede escolhida, já preenchida com o link e o título do conteúdo, sem sair da página atual.

Arquivos criados:

src/app/shared/components/share-buttons/share-buttons.component.ts
src/app/shared/components/share-buttons/share-buttons.component.html
src/app/shared/components/share-buttons/share-buttons.component.scss

Arquivos alterados:

src/app/pages/news/news-detail.component.ts e .html
src/app/pages/personalities/personalities-detail.component.ts e .html
src/app/pages/videos/video-detail/video-detail.component.ts e .html

Como testar:

Rodar ng serve e abrir qualquer notícia, personalidade ou vídeo. Conferir se aparece a linha Compartilhar com os cinco ícones logo após a descrição, e se cada um abre a janela de compartilhamento correta da respectiva rede social.